### PR TITLE
cleanup tests

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -5,17 +5,14 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"maps"
 	"math"
 	rand "math/rand/v2"
 	"os"
-	"reflect"
 	"slices"
 	"strings"
 	"testing"
 
 	"github.com/phiryll/kv"
-	"github.com/stretchr/testify/assert"
 )
 
 // No benchmark can have a truly random element, random seeds must be constants!
@@ -392,51 +389,6 @@ func createBenchWordStoreConfigs() []*storeConfig {
 
 func createBenchStoreConfigs() []*storeConfig {
 	return append(createBenchRandomStoreConfigs(), createBenchWordStoreConfigs()...)
-}
-
-func TestBenchStoreConfigs(t *testing.T) {
-	t.Parallel()
-	for _, config := range benchStoreConfigs {
-		t.Run(config.name, func(t *testing.T) {
-			t.Parallel()
-			assert.Len(t, config.entries, config.size)
-			assert.Equal(t, len(config.present), len(config.absent))
-			assert.Equal(t, 1, len(config.present[0])+len(config.absent[0]))
-			assert.Equal(t, 1<<8, len(config.present[1])+len(config.absent[1]))
-			assert.Equal(t, 1<<16, len(config.present[2])+len(config.absent[2]))
-			assert.Len(t, config.forward, 1<<16)
-			assert.Len(t, config.reverse, 1<<16)
-
-			present := maps.Clone(config.entries)
-			for i := range len(config.present) {
-				if i > 2 {
-					assert.Len(t, config.absent[i], 1<<16)
-				}
-				for _, k := range config.absent[i] {
-					assert.Len(t, k, i)
-					_, ok := present[string(k)]
-					assert.False(t, ok)
-				}
-				for _, k := range config.present[i] {
-					assert.Len(t, k, i)
-					_, ok := present[string(k)]
-					assert.True(t, ok)
-					delete(present, string(k))
-				}
-			}
-			assert.Empty(t, present)
-		})
-	}
-}
-
-func TestBenchStoreConfigRepeatability(t *testing.T) {
-	t.Parallel()
-	for i, config := range createBenchStoreConfigs() {
-		t.Run(config.name, func(t *testing.T) {
-			t.Parallel()
-			assert.True(t, reflect.DeepEqual(benchStoreConfigs[i], config))
-		})
-	}
 }
 
 // This helps to understand how factory() can impact other benchmarks which use it.

--- a/bench_test.go
+++ b/bench_test.go
@@ -156,6 +156,8 @@ func BenchmarkChildBounds(b *testing.B) {
 		bounds *Bounds
 		keys   keySet
 	}{
+		// No need to benchmark reverse bounds, the code is the same.
+
 		// no common prefix
 		{
 			From(nil).To(empty),
@@ -167,14 +169,11 @@ func BenchmarkChildBounds(b *testing.B) {
 		},
 		{
 			From(nil).To(high),
-			keySet{
-				empty, nextKey(empty), before, high[:1], high[:2], high[:3],
-				prevKey(high), high, nextKey(high), after,
-			},
+			keySet{empty, high[:1], high[:2], high[:3], prevKey(high), high, nextKey(high), after},
 		},
 		{
 			From(nil).To(nil),
-			keySet{empty, nextKey(empty), within},
+			keySet{empty, nextKey(empty), after},
 		},
 		{
 			From(empty).To(nextKey(empty)),
@@ -182,36 +181,33 @@ func BenchmarkChildBounds(b *testing.B) {
 		},
 		{
 			From(empty).To(high),
-			keySet{
-				empty, nextKey(empty), before, high[:1], high[:2], high[:3],
-				prevKey(high), high, nextKey(high), after,
-			},
+			keySet{empty, nextKey(empty), high[:1], high[:2], high[:3], prevKey(high), high, nextKey(high), after},
 		},
 		{
 			From(empty).To(nil),
-			keySet{empty, nextKey(empty), within},
+			keySet{empty, nextKey(empty), after},
 		},
 		{
 			From(nextKey(empty)).To(high),
 			keySet{
-				empty, nextKey(empty), nextKey(nextKey(empty)), before, high[:1], high[:2], high[:3],
+				empty, nextKey(empty), nextKey(nextKey(empty)), high[:1], high[:2], high[:3],
 				prevKey(high), high, nextKey(high), after,
 			},
 		},
 		{
 			From(nextKey(empty)).To(nil),
-			keySet{empty, nextKey(empty), nextKey(nextKey(empty)), within},
+			keySet{empty, nextKey(empty), nextKey(nextKey(empty)), after},
 		},
 		{
 			From(low).To(high),
 			keySet{
-				empty, nextKey(empty), before, low[:1], low[:2], low[:3], prevKey(low), low, nextKey(low),
-				within, high[:1], high[:2], high[:3], prevKey(high), high, nextKey(high), after,
+				empty, nextKey(empty), low[:1], low[:2], low[:3], prevKey(low), low, nextKey(low),
+				high[:1], high[:2], high[:3], prevKey(high), high, nextKey(high), after,
 			},
 		},
 		{
 			From(low).To(nil),
-			keySet{empty, nextKey(empty), before, low[:1], low[:2], low[:3], prevKey(low), low, nextKey(low), after},
+			keySet{empty, nextKey(empty), low[:1], low[:2], low[:3], prevKey(low), low, nextKey(low), after},
 		},
 
 		// 2 byte common prefix
@@ -233,20 +229,11 @@ func BenchmarkChildBounds(b *testing.B) {
 		},
 	} {
 		b.Run(fmt.Sprintf("bounds=%s", tt.bounds), func(b *testing.B) {
-			forward := tt.bounds
-			reverse := From(tt.bounds.End).DownTo(tt.bounds.Begin)
 			for _, k := range tt.keys {
 				b.Run("key="+kv.KeyName(k), func(b *testing.B) {
-					b.Run("dir=forward", func(b *testing.B) {
-						for b.Loop() {
-							kv.TestingChildBounds(forward, k)
-						}
-					})
-					b.Run("dir=reverse", func(b *testing.B) {
-						for b.Loop() {
-							kv.TestingChildBounds(reverse, k)
-						}
-					})
+					for b.Loop() {
+						kv.TestingChildBounds(tt.bounds, k)
+					}
 				})
 			}
 		})

--- a/bench_test.go
+++ b/bench_test.go
@@ -455,7 +455,7 @@ func TestBenchStoreConfigRepeatability(t *testing.T) {
 // This helps to understand how factory() can impact other benchmarks which use it.
 func BenchmarkFactory(b *testing.B) {
 	for _, def := range implDefs {
-		b.Run("impl="+def.name, func(b *testing.B) {
+		b.Run(def.name, func(b *testing.B) {
 			for b.Loop() {
 				_ = def.factory()
 			}
@@ -501,7 +501,7 @@ func BenchmarkSparse(b *testing.B) {
 	}
 	shuffle(keys, random)
 	for _, def := range implDefs {
-		b.Run("impl="+def.name, func(b *testing.B) {
+		b.Run(def.name, func(b *testing.B) {
 			for b.Loop() {
 				store := def.factory()
 				for _, k := range keys {
@@ -543,7 +543,7 @@ func BenchmarkDense(b *testing.B) {
 			{"/keyLen=2", keySets[1]},
 			{"/keyLen=3", keySets[2]},
 		} {
-			b.Run("impl="+def.name+tt.name, func(b *testing.B) {
+			b.Run(def.name+tt.name, func(b *testing.B) {
 				for b.Loop() {
 					store := def.factory()
 					for _, k := range tt.keys {

--- a/bench_test.go
+++ b/bench_test.go
@@ -598,7 +598,6 @@ func BenchmarkSet(b *testing.B) {
 //nolint:gocognit
 func BenchmarkGet(b *testing.B) {
 	for _, bench := range createTestStores(benchStoreConfigs) {
-		original := bench.store
 		b.Run(bench.name, func(b *testing.B) {
 			for keyLen := 8; keyLen < len(bench.config.present); keyLen += 4 {
 				b.Run(fmt.Sprintf("keyLen=%d/existing=true", keyLen), func(b *testing.B) {
@@ -606,10 +605,9 @@ func BenchmarkGet(b *testing.B) {
 					if len(present) == 0 {
 						b.Skipf("no present keys of length %d", keyLen)
 					}
-					store := original.Clone()
 					i := 0
 					for b.Loop() {
-						store.Get(present[i%len(present)])
+						bench.store.Get(present[i%len(present)])
 						i++
 					}
 				})
@@ -618,10 +616,9 @@ func BenchmarkGet(b *testing.B) {
 					if len(absent) == 0 {
 						b.Skipf("no absent keys of length %d", keyLen)
 					}
-					store := original.Clone()
 					i := 0
 					for b.Loop() {
-						store.Get(absent[i%len(absent)])
+						bench.store.Get(absent[i%len(absent)])
 						i++
 					}
 				})

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -69,13 +69,13 @@ func TestBaseline(t *testing.T) {
 	t.Parallel()
 	fuzzStores := createTestStores(fuzzStoreConfigs)
 	ref := createReferenceStore(fuzzStoreConfigs[0])
-	refForward := collect(ref.Range(forwardAll))
-	refReverse := collect(ref.Range(reverseAll))
+	refForward := ref.Range(forwardAll)
+	refReverse := ref.Range(reverseAll)
 	for _, fuzz := range fuzzStores {
 		t.Run(fuzz.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, refForward, collect(fuzz.store.Range(forwardAll)), "forward")
-			assert.Equal(t, refReverse, collect(fuzz.store.Range(reverseAll)), "reverse")
+			assertItersEqual(t, refForward, fuzz.store.Range(forwardAll), "forward")
+			assertItersEqual(t, refReverse, fuzz.store.Range(reverseAll), "reverse")
 		})
 	}
 }
@@ -142,11 +142,11 @@ func FuzzRange(f *testing.F) {
 		}
 		forward := From(begin).To(end)
 		reverse := From(end).DownTo(begin)
-		refForward := collect(ref.Range(forward))
-		refReverse := collect(ref.Range(reverse))
+		refForward := ref.Range(forward)
+		refReverse := ref.Range(reverse)
 		for _, fuzz := range fuzzStores {
-			assert.Equal(t, refForward, collect(fuzz.store.Range(forward)), "%s: %s", fuzz.def.name, forward)
-			assert.Equal(t, refReverse, collect(fuzz.store.Range(reverse)), "%s: %s", fuzz.def.name, reverse)
+			assertItersEqual(t, refForward, fuzz.store.Range(forward), "%s: %s", fuzz.def.name, forward)
+			assertItersEqual(t, refReverse, fuzz.store.Range(reverse), "%s: %s", fuzz.def.name, reverse)
 		}
 	})
 }

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -65,21 +65,6 @@ func createFuzzStoreConfigs(size int) []*storeConfig {
 	return []*storeConfig{&config}
 }
 
-func TestBaseline(t *testing.T) {
-	t.Parallel()
-	fuzzStores := createTestStores(fuzzStoreConfigs)
-	ref := createReferenceStore(fuzzStoreConfigs[0])
-	refForward := ref.Range(forwardAll)
-	refReverse := ref.Range(reverseAll)
-	for _, fuzz := range fuzzStores {
-		t.Run(fuzz.name, func(t *testing.T) {
-			t.Parallel()
-			assertItersEqual(t, refForward, fuzz.store.Range(forwardAll), "forward")
-			assertItersEqual(t, refReverse, fuzz.store.Range(reverseAll), "reverse")
-		})
-	}
-}
-
 func FuzzGet(f *testing.F) {
 	fuzzStores := createTestStores(fuzzStoreConfigs)
 	ref := createReferenceStore(fuzzStoreConfigs[0])

--- a/kv_test.go
+++ b/kv_test.go
@@ -236,16 +236,6 @@ func asCloneable(factory func() kv.Store[byte]) func() TestStore {
 	}
 }
 
-func emptySeqInt(_ func(int) bool) {}
-
-func emptyAdjInt(_ int) iter.Seq[int] {
-	return emptySeqInt
-}
-
-func emptyPathAdjInt(_ []int) iter.Seq[int] {
-	return emptySeqInt
-}
-
 func cmpEntryForward(a, b entry) int {
 	return bytes.Compare(a.key, b.key)
 }

--- a/kv_test.go
+++ b/kv_test.go
@@ -67,9 +67,9 @@ const (
 
 var (
 	implDefs = []*implDef{
-		{"reference", newReference},
-		{"pointer-trie", asCloneable(kv.NewPointerTrie[byte])},
-		{"array-trie", asCloneable(kv.NewArrayTrie[byte])},
+		{"impl=reference", newReference},
+		{"impl=pointer-trie", asCloneable(kv.NewPointerTrie[byte])},
+		{"impl=array-trie", asCloneable(kv.NewArrayTrie[byte])},
 	}
 
 	From       = kv.From
@@ -288,13 +288,13 @@ func createReferenceStore(config *storeConfig) TestStore {
 
 func createTestStores(storeConfigs []*storeConfig) []*testStore {
 	result := []*testStore{}
-	for _, def := range implDefs {
-		for _, config := range storeConfigs {
+	for _, config := range storeConfigs {
+		for _, def := range implDefs {
 			store := def.factory()
 			for k, v := range config.entries {
 				store.Set([]byte(k), v)
 			}
-			name := fmt.Sprintf("impl=%s/%s", def.name, config.name)
+			name := config.name + "/" + def.name
 			result = append(result, &testStore{name, store, def, config})
 		}
 	}

--- a/kv_test.go
+++ b/kv_test.go
@@ -236,14 +236,6 @@ func asCloneable(factory func() kv.Store[byte]) func() TestStore {
 	}
 }
 
-func cmpEntryForward(a, b entry) int {
-	return bytes.Compare(a.key, b.key)
-}
-
-func cmpEntryReverse(a, b entry) int {
-	return bytes.Compare(b.key, a.key)
-}
-
 func collect(itr iter.Seq2[[]byte, byte]) []entry {
 	entries := []entry{}
 	for k, v := range itr {
@@ -410,9 +402,9 @@ func assertSame(t *testing.T, entries map[string]byte, store TestStore) {
 		assert.Equal(t, expected, actual)
 		sliceEntries = append(sliceEntries, entry{[]byte(k), expected})
 	}
-	slices.SortFunc(sliceEntries, cmpEntryForward)
+	slices.SortFunc(sliceEntries, func(a, b entry) int { return bytes.Compare(a.key, b.key) })
 	assert.Equal(t, sliceEntries, collect(store.Range(forwardAll)))
-	slices.SortFunc(sliceEntries, cmpEntryReverse)
+	slices.SortFunc(sliceEntries, func(a, b entry) int { return bytes.Compare(b.key, a.key) })
 	assert.Equal(t, sliceEntries, collect(store.Range(reverseAll)))
 }
 

--- a/kv_test.go
+++ b/kv_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"iter"
 	"math/bits"
-	"reflect"
 	"slices"
 	"strings"
 	"testing"
@@ -269,13 +268,6 @@ func createTestStoreConfigs() []*storeConfig {
 		result = append(result, &config)
 	}
 	return result
-}
-
-func TestTestStoreConfigRepeatability(t *testing.T) {
-	t.Parallel()
-	for i, config := range createTestStoreConfigs() {
-		assert.True(t, reflect.DeepEqual(testStoreConfigs[i], config))
-	}
 }
 
 func createReferenceStore(config *storeConfig) TestStore {

--- a/kv_test.go
+++ b/kv_test.go
@@ -806,6 +806,10 @@ func TestFail9(t *testing.T) {
 			key := []byte{0x23}
 			store.Set(key, 6)
 			store.Delete(key)
+			// make sure reference.dirty is false
+			for range store.Range(forwardAll) {
+				break
+			}
 			assert.Equal(t, expected, sStore.String())
 		})
 	}

--- a/kv_test.go
+++ b/kv_test.go
@@ -2,12 +2,9 @@ package kv_test
 
 import (
 	"bytes"
-	"encoding/binary"
 	"fmt"
 	"iter"
-	"math"
 	"math/bits"
-	rand "math/rand/v2"
 	"reflect"
 	"slices"
 	"strings"
@@ -242,45 +239,6 @@ func collect(itr iter.Seq2[[]byte, byte]) []entry {
 		entries = append(entries, entry{k, v})
 	}
 	return entries
-}
-
-func randomBytes(n int, random *rand.Rand) []byte {
-	if n == 0 {
-		return []byte{}
-	}
-	k := (n-1)/8 + 1
-	b := make([]byte, k*8)
-	for i := range k {
-		binary.BigEndian.PutUint64(b[i*8:], random.Uint64())
-	}
-	return b[:n]
-}
-
-func randomByte(random *rand.Rand) byte {
-	return byte(random.UintN(256))
-}
-
-// Returns a random key of with length chosen from a roughly normal distribution
-// with the given mean. Lengths will range from 0 to 2*mean.
-func randomKey(meanLen int, random *rand.Rand) []byte {
-	const bound = 4.0 // chosen experimentally
-	val := random.NormFloat64()
-	for val < -bound || val > +bound {
-		val = random.NormFloat64()
-	}
-	// val is in [-bound, +bound], translate that to [0, 2*mean]
-	val = (val + bound) * float64(meanLen) / bound
-	return randomBytes(int(math.Round(val)), random)
-}
-
-func randomFixedLengthKey(keyLen int, random *rand.Rand) []byte {
-	return randomBytes(keyLen, random)
-}
-
-func shuffle[S ~[]E, E any](slice S, random *rand.Rand) {
-	random.Shuffle(len(slice), func(i, j int) {
-		slice[i], slice[j] = slice[j], slice[i]
-	})
 }
 
 // storeConfigs for all possible subsequences of presentKeys.

--- a/reference_test.go
+++ b/reference_test.go
@@ -1,7 +1,7 @@
 package kv_test
 
 import (
-	"cmp"
+	"bytes"
 	"fmt"
 	"iter"
 	"maps"
@@ -11,88 +11,155 @@ import (
 	"github.com/phiryll/kv"
 )
 
+// reference serves as an expected value to compare against while testing,
+// and a source of entries from which to create a new Store.
+// This implementation is meant to be as trivially correct as possible.
+type reference struct {
+	entries map[string]byte
+	ascKeys [][]byte
+	dirty   bool
+}
+
 func newReference() TestStore {
-	return reference{}
+	return &reference{
+		entries: map[string]byte{},
+	}
 }
 
-// reference implements the TestStore interface, but it is not a trie.
-// This serves as an expected value to compare against a Store[byte] implementation while testing.
-type reference map[string]byte
-
-func (r reference) Clone() TestStore {
-	return maps.Clone(r)
+func (r *reference) Clone() TestStore {
+	return &reference{
+		maps.Clone(r.entries),
+		slices.Clone(r.ascKeys),
+		r.dirty,
+	}
 }
 
-func (r reference) Set(key []byte, value byte) (byte, bool) {
+func (r *reference) refresh() {
+	if !r.dirty {
+		return
+	}
+	var keys [][]byte
+	for key := range r.entries {
+		keys = append(keys, []byte(key))
+	}
+	slices.SortFunc(keys, bytes.Compare)
+	r.ascKeys = keys
+	r.dirty = false
+}
+
+func (r *reference) Get(key []byte) (byte, bool) {
 	if key == nil {
 		panic("key must be non-nil")
 	}
-	index := string(key)
-	prev, ok := r[index]
-	r[index] = value
+	value, ok := r.entries[string(key)]
+	return value, ok
+}
+
+func (r *reference) Set(key []byte, value byte) (byte, bool) {
+	if key == nil {
+		panic("key must be non-nil")
+	}
+	prev, ok := r.entries[string(key)]
+	r.entries[string(key)] = value
+	r.ascKeys = nil
+	r.dirty = true
+	return prev, ok
+}
+
+func (r *reference) Delete(key []byte) (byte, bool) {
+	if key == nil {
+		panic("key must be non-nil")
+	}
+	value, ok := r.entries[string(key)]
 	if ok {
-		return prev, true
+		delete(r.entries, string(key))
+		r.ascKeys = nil
+		r.dirty = true
 	}
-	return 0, false
-}
-
-func (r reference) Get(key []byte) (byte, bool) {
-	if key == nil {
-		panic("key must be non-nil")
-	}
-	value, ok := r[string(key)]
 	return value, ok
 }
 
-func (r reference) Delete(key []byte) (byte, bool) {
-	if key == nil {
-		panic("key must be non-nil")
-	}
-	index := string(key)
-	value, ok := r[index]
-	delete(r, index)
-	return value, ok
-}
-
-// Does not work with NaN.
-func negCompare[T cmp.Ordered](x, y T) int {
-	if x < y {
-		return +1
-	}
-	if x > y {
-		return -1
-	}
-	return 0
-}
-
-func (r reference) Range(bounds *Bounds) iter.Seq2[[]byte, byte] {
+func (r *reference) Range(bounds *Bounds) iter.Seq2[[]byte, byte] {
 	bounds = bounds.Clone()
+	if bounds.IsReverse {
+		return r.Desc(bounds.End, bounds.Begin)
+	}
+	return r.Asc(bounds.Begin, bounds.End)
+}
+
+// Future methods on Store, replacing Range.
+// Desc will behave differently, with low inclusive and high exclusive.
+
+func (r *reference) All() iter.Seq2[[]byte, byte] {
 	return func(yield func([]byte, byte) bool) {
-		var keys []string
-		for k := range r {
-			if bounds.CompareKey([]byte(k)) == 0 {
-				keys = append(keys, k)
-			}
-		}
-		if bounds.IsReverse {
-			slices.SortFunc(keys, negCompare)
-		} else {
-			slices.Sort(keys)
-		}
-		for _, k := range keys {
-			if !yield([]byte(k), r[k]) {
+		for k, v := range r.entries {
+			if !yield([]byte(k), v) {
 				return
 			}
 		}
 	}
 }
 
-func (r reference) String() string {
-	var s strings.Builder
-	s.WriteString("{")
-	for _, k := range slices.Sorted(maps.Keys(r)) {
-		fmt.Fprintf(&s, "%s:%v, ", kv.KeyName([]byte(k)), r[k])
+func (r *reference) between(low, high []byte) [][]byte {
+	lowIndex, highIndex := 0, len(r.ascKeys)
+	if low != nil {
+		lowIndex, _ = slices.BinarySearchFunc(r.ascKeys, low, bytes.Compare)
 	}
+	if high != nil {
+		highIndex, _ = slices.BinarySearchFunc(r.ascKeys, high, bytes.Compare)
+	}
+	return r.ascKeys[lowIndex:highIndex]
+}
+
+func (r *reference) Asc(low, high []byte) iter.Seq2[[]byte, byte] {
+	if low != nil && high != nil && bytes.Compare(low, high) >= 0 {
+		panic("low >= high")
+	}
+	return func(yield func([]byte, byte) bool) {
+		r.refresh()
+		for _, key := range r.between(low, high) {
+			if !yield(key, r.entries[string(key)]) {
+				return
+			}
+		}
+	}
+}
+
+func (r *reference) Desc(low, high []byte) iter.Seq2[[]byte, byte] {
+	if low != nil && high != nil && bytes.Compare(low, high) >= 0 {
+		panic("low >= high")
+	}
+	return func(yield func([]byte, byte) bool) {
+		r.refresh()
+		a, b := low, high
+		if a != nil {
+			a = nextKey(a)
+		}
+		if b != nil {
+			b = nextKey(b)
+		}
+		for _, key := range slices.Backward(r.between(a, b)) {
+			if !yield(key, r.entries[string(key)]) {
+				return
+			}
+		}
+	}
+}
+
+func (r *reference) String() string {
+	var s strings.Builder
+	s.WriteString("{\n")
+	fmt.Fprintf(&s, "  dirty: %v\n", r.dirty)
+	s.WriteString("  entries: {")
+	for key, value := range r.entries {
+		fmt.Fprintf(&s, "%s:%02X, ", kv.KeyName([]byte(key)), value)
+	}
+	s.WriteString(" }\n")
+	s.WriteString("  ascKeys: {")
+	for _, key := range r.ascKeys {
+		fmt.Fprintf(&s, "%s, ", kv.KeyName(key))
+	}
+	s.WriteString(" }\n")
 	s.WriteString("}")
 	return s.String()
 }

--- a/traversers_test.go
+++ b/traversers_test.go
@@ -9,6 +9,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func emptySeqInt(_ func(int) bool) {}
+
+func emptyAdjInt(_ int) iter.Seq[int] {
+	return emptySeqInt
+}
+
+func emptyPathAdjInt(_ []int) iter.Seq[int] {
+	return emptySeqInt
+}
+
 // adjInt returns a simple adjFunction[int] for testing traversals.
 // If k <= limit, children(k) == [4*k+1, 4*k+2, 4*k+3].
 // If k > limit, children(k) == [].


### PR DESCRIPTION
Still much more to do here. Not testing by key length is next.

- **Clean up one-off unit tests.**
- **Move traverser-specific test functions to traversers_test.go.**
- **Inline some helper functions that are only used once.**
- **Move randomization functions to bench_test.go.**
- **Add helper function for testing an early yield().**
- **Compare iterators to avoid building slices.**
- **Structure bench and test names as config first, impl second.**
- **Have reference cache sorted keys.**
- **No need to clone the store in BenchmarkGet.**
- **Remove some benchmarks for ChildBounds.**
- **Remove some unneeded unit tests.**
